### PR TITLE
Fiix adding unique "Post Fields" to form

### DIFF
--- a/assets/admin/js/admin.js
+++ b/assets/admin/js/admin.js
@@ -160,7 +160,7 @@ jQuery(document).ready(function(jQuery) {
 		var exist = jQuery("#sortable_buddyforms_elements .bf_" + fieldtype);
 
 		if(unique === 'unique'){
-			if (exist !== null && typeof exist === 'object'){
+			if (exist !== null && typeof exist === 'object' && exist.length > 0){
 				alert('This element can only be added once into each form');
 				return false;
 		    }


### PR DESCRIPTION
On my bleeding edge install (WordPress 4.6-alpha-37307) I cannot add any unique "Post Fields" such as "Title" and "Content" to a form. This is because the "is this element added already?" check doesn't test for the presence of an actual element - only a jQuery object.

PS, thank you for making this available on GitHub. I'm evaluating the plugin for a client project and didn't want tell them to buy it without seeing working. Happily, I can now recommend it!