### PR TITLE
Fix rewrite rules in multisite

### DIFF
--- a/includes/rewrite-roles.php
+++ b/includes/rewrite-roles.php
@@ -11,10 +11,6 @@ add_action( 'init', 'buddyforms_attached_page_rewrite_rules' );
 function buddyforms_attached_page_rewrite_rules( $flush_rewrite_rules = false ) {
 	global $buddyforms;
 
-	if ( ! is_admin() ) {
-		return;
-	}
-
 	if ( ! $buddyforms ) {
 		return;
 	}
@@ -44,10 +40,6 @@ function buddyforms_attached_page_rewrite_rules( $flush_rewrite_rules = false ) 
  */
 add_filter( 'query_vars', 'buddyforms_attached_page_query_vars' );
 function buddyforms_attached_page_query_vars( $query_vars ) {
-
-	if ( is_admin() ) {
-		return $query_vars;
-	}
 
 	$query_vars[] = 'bf_action';
 	$query_vars[] = 'bf_form_slug';


### PR DESCRIPTION
In WordPress Multisite, the BuddyForms rewrite rules are not being applied on the front-end, causing `create`, `edit` and `view` endpoints to result in 404s. This PR removes some unnecessary checks for WordPress admin in `buddyforms_attached_page_rewrite_rules()` and `buddyforms_attached_page_query_vars()` such that BuddyForms display as expected.