### PR TITLE
Add filter for taxonomy create title

### DIFF
--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -504,7 +504,8 @@ function bf_form_elements( $form, $args ) {
 							$form->addElement( new Element_HTML( $dropdown ) );
 
 							if ( isset( $customfield['creat_new_tax'] ) ) {
-								$form->addElement( new Element_Textbox( __( 'Create a new ', 'buddyforms' ) . $customfield['name'], $slug . '_creat_new_tax', array( 'class' => 'settings-input' ) ) );
+								$el_title = apply_filters( 'buddyforms_create_new_tax_title', sprintf( __( 'Create a new %s', 'buddyforms' ), $customfield['name'] ), $form_slug, $customfield );
+								$form->addElement( new Element_Textbox( $el_title, $slug . '_creat_new_tax', array( 'class' => 'settings-input' ) ) );
 							}
 						}
 


### PR DESCRIPTION
The title of the Create New Taxonomy Term form element does not always make sense as it stands. If, for example, I add a title to the Add Term form element that says "Add tags to your poem", then the the title of the Create New Taxonomy Term form element becomes "Create a new Add tags to your poem". This filter allows me to define a title for the form element that does makes sense.