### PR TITLE
Adding a hook

### DIFF
--- a/includes/form/form.php
+++ b/includes/form/form.php
@@ -148,7 +148,7 @@ function buddyforms_create_edit_form( $args ) {
 		'the_post'     => $the_post,
 		'post_parent'  => $post_parent,
 		'customfields' => $customfields,
-		'post_id'      => $post_id,
+		'post_id'      => apply_filters('buddyforms_set_post_id_for_draft', $post_id, $args, $customfields),
 		'form_slug'    => $form_slug,
 		'form_notice'  => $form_notice,
 	);


### PR DESCRIPTION
Add the hook to ge the post id from an external function, is used in the Woocommerce Elements to create the post draft to save all options of the product