### PR TITLE
fixed backend tax empty bug

### DIFF
--- a/includes/form/form-control.php
+++ b/includes/form/form-control.php
@@ -609,6 +609,10 @@ function buddyforms_update_post_meta( $post_id, $customfields ) {
 		// Save taxonomies if needed
 		// taxonomy, category, tags
 		if ( $customfield['type'] == 'taxonomy' || $customfield['type'] == 'category' || $customfield['type'] == 'tags' ) :
+			//return when on backend post edit page
+			if( is_admin() && !defined( 'DOING_AJAX' ) ) {
+				return;
+			}
 
 
 			if ( ! isset( $customfield['taxonomy'] ) ) {


### PR DESCRIPTION
When saving a post in the edit page in the WordPress dashboard the taxonomies that were used in a buddyforms form were always deleted. So it was impossible to save taxonomies used in the forms on the back-end edit page. The "quick edit" did not have this problem. 

The problem I found is that in the back-end  'isset( $_POST[ $customfield['slug'] ] )' is not true so the following code is executed: wp_delete_object_term_relationships( $post_id, $customfield['taxonomy'] );

I added an admin page check so the code is not executed in the back-end.