### PR TITLE
gallery bug fixed

### DIFF
--- a/BuddyForms.php
+++ b/BuddyForms.php
@@ -391,7 +391,7 @@ if ( ! class_exists( 'BuddyForms' ) ) {
 			wp_enqueue_script( 'jquery-ui-core' );
 			wp_enqueue_script( 'jquery-ui-widgets' );
 			wp_enqueue_script( 'jquery-ui-datepicker' );
-
+			wp_enqueue_script( 'mce-view' );
 			// jQuery Validation http://jqueryvalidation.org/
 			wp_enqueue_script( 'jquery-validation', plugins_url( 'assets/resources/jquery.validate.min.js', __FILE__ ), array( 'jquery' ) );
 

--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -184,6 +184,7 @@ function buddyforms_form_elements( $form, $args ) {
 						break;
 
 					case 'content':
+						remove_filter( 'the_content', 'do_shortcode', 11 );
 						add_filter( 'tiny_mce_before_init', 'buddyforms_tinymce_setup_function' );
 						$buddyforms_form_content_val = false;
 						if ( isset( $_POST['buddyforms_form_content'] ) ) {


### PR DESCRIPTION
When adding galleries on front-end edit page, they didn't display well so I added mce-view. 

When editing a post that contains a gallery the editor just displayed random images instead of the gallery. I believe WordPress executed the do_shortcode() function on the content so instead of the shortcode it was the actual gallery html (for some reason with random images). I added 'remove_filter( 'the_content', 'do_shortcode', 11 );' to the content case which seems to have fixed the issue while also allowing other shortcodes to be executed.
