### PR TITLE
Avoid send the notification id the status is the same

### DIFF
--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -261,6 +261,10 @@ add_action( 'transition_post_status', 'buddyforms_transition_post_status', 10, 3
 function buddyforms_transition_post_status( $new_status, $old_status, $post ) {
 	global $form_slug, $buddyforms;
 
+    if ($new_status === $old_status) {
+        return;
+    }
+
 	if ( empty( $form_slug ) ) {
 		$form_slug = get_post_meta( $post->ID, '_bf_form_slug', true );
 	}


### PR DESCRIPTION
Including Patty O'Hara suggestion to avoid send the email notification if the old status is equal to the new status. This will avoid to send the notification twice

https://github.com/BuddyForms/BuddyForms/issues/235