### PR TITLE
* Adding a code to show the related tabs in base of the form type 

### DIFF
--- a/assets/admin/js/admin.js
+++ b/assets/admin/js/admin.js
@@ -107,6 +107,8 @@ function load_formbuilder_template(template) {
 	                            buddyform_apply_template_to_element(jQuery('[name="buddyforms_options[' + i2 + ']"]'), form_setup);
                             }
                             jQuery('.bf-select2').select2();
+                            // Check the form type and only display the relevant form setup tabs
+                            from_setup_form_type(jQuery('#bf-form-type-select').val());
                         });
                         break;
                     default:


### PR DESCRIPTION
Adding a code to show the related tabs in base of the form type select in the templates

https://github.com/BuddyForms/BuddyForms/issues/172