### PR TITLE
Multiples fixes

### DIFF
--- a/includes/admin/form-builder/meta-boxes/metabox-registration.php
+++ b/includes/admin/form-builder/meta-boxes/metabox-registration.php
@@ -94,23 +94,8 @@ class BuddyFormsMetaBoxRegistration {
 		}
 		$form_setup[] = $element;
 
-		// Get all Pages
-		$pages = get_pages( array(
-			'sort_order'  => 'asc',
-			'sort_column' => 'post_title',
-			'parent'      => 0,
-			'post_type'   => 'page',
-			'post_status' => 'publish'
-		) );
-
-		// Generate the pages Array
-		$all_pages             = Array();
-		$all_pages['referrer'] = 'Select a Page';
-		$all_pages['referrer'] = 'Referrer';
-		$all_pages['home']     = 'Homepage';
-		foreach ( $pages as $page ) {
-			$all_pages[ $page->ID ] = $page->post_title;
-		}
+		//Get all Pages
+		$all_pages = $this->get_activation_page_list();
 
 		$activation_page = isset( $buddyform['registration']['activation_page'] ) ? $buddyform['registration']['activation_page'] : 'none';
 
@@ -163,6 +148,33 @@ class BuddyFormsMetaBoxRegistration {
 		) );
 
 		buddyforms_display_field_group_table( $form_setup );
+	}
+
+	/**
+	 * Get the list of pages to show in the list of the Activation Page
+	 * @return array
+	 */
+	public function get_activation_page_list() {
+		$home_page_id = get_option( 'page_on_front' );
+		// Get all Pages
+		$pages = get_pages( array(
+			'sort_order'  => 'asc',
+			'sort_column' => 'post_title',
+			'parent'      => 0,
+			'exclude'     => array( $home_page_id ),
+			'post_type'   => 'page',
+			'post_status' => 'publish'
+		) );
+
+		// Generate the pages Array
+		$all_pages             = array();
+		$all_pages['referrer'] = __( 'Select a Page', 'buddyforms' );
+		$all_pages['home']     = __( 'Homepage', 'buddyforms' );
+		foreach ( $pages as $page ) {
+			$all_pages[ $page->ID ] = $page->post_title;
+		}
+
+		return $all_pages;
 	}
 
 	/**
@@ -220,23 +232,9 @@ class BuddyFormsMetaBoxRegistration {
 
 		//Explain the redirection on update
 		echo sprintf( '<p>%s</p><br>', __( 'To select the page where the user should land on Update the User Profile use te Form Submission options ', 'buddyforms' ) );
-		// Get all Pages
-		$pages = get_pages( array(
-			'sort_order'  => 'asc',
-			'sort_column' => 'post_title',
-			'parent'      => 0,
-			'post_type'   => 'page',
-			'post_status' => 'publish'
-		) );
 
-		// Generate the pages Array
-		$all_pages             = Array();
-		$all_pages['referrer'] = 'Select a Page';
-		$all_pages['referrer'] = 'Referrer';
-		$all_pages['home']     = 'Homepage';
-		foreach ( $pages as $page ) {
-			$all_pages[ $page->ID ] = $page->post_title;
-		}
+		//Get all Pages
+		$all_pages = $this->get_activation_page_list();
 
 		$activation_page = isset( $buddyform['registration']['activation_page'] ) ? $buddyform['registration']['activation_page'] : 'none';
 

--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -112,7 +112,7 @@ function buddyforms_form_elements( $form, $args ) {
 						// @since 2.3 we remove is_admin form the if because is not clear
 						// old condition
 						//if ( ! ( is_user_logged_in() && isset( $customfield['hide_if_logged_in'] ) ) && ! is_admin() )
-						if ( is_user_logged_in() && ! isset( $customfield['hide_if_logged_in'] ) ) {
+						if ( ! isset( $customfield['hide_if_logged_in'] ) ) {
 							if ( $buddyforms[ $form_slug ]['form_type'] == 'registration' && is_user_logged_in() ) {
 								$element_attr['value'] = $current_user->user_login;
 							}
@@ -124,7 +124,7 @@ function buddyforms_form_elements( $form, $args ) {
 						// @since 2.3 we remove is_admin form the if because is not clear
 						// old condition
 						//if ( ! ( is_user_logged_in() && isset( $customfield['hide_if_logged_in'] ) ) && ! is_admin() )
-						if ( is_user_logged_in() && ! isset( $customfield['hide_if_logged_in'] ) ) {
+						if ( ! isset( $customfield['hide_if_logged_in'] ) ) {
 							if ( $buddyforms[ $form_slug ]['form_type'] == 'registration' && is_user_logged_in() ) {
 								$element_attr['value'] = $current_user->user_email;
 							}

--- a/includes/form/form.php
+++ b/includes/form/form.php
@@ -126,7 +126,7 @@ function buddyforms_create_edit_form( $args ) {
 	}
 
 	// if post edit screen is displayed
-	if ( ! empty( $post_id ) ) {
+	if ( ! empty( $post_id ) && $buddyforms[ $form_slug ]['form_type'] !== 'registration') {
 
 		if ( ! empty( $revision_id ) ) {
 			$the_post = get_post( $revision_id );


### PR DESCRIPTION
*Removed the home page from the activation page list. Now to redirect to WordPress home is necessary to use the HomePage option in the list.
* Avoid asking for permission to show the form in the registration forms.
* Fixed the fields email and user_login to show if the user is not logged in.

fixes #362