### PR TITLE
Form builder grid option not working for images

### DIFF
--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -570,13 +570,14 @@ function buddyforms_form_elements( $form, $args ) {
 						$label_name = $customfield['name'];
 
 						$message = __( 'Drop the image here to upload', 'buddyforms' );
-						$box     = "<div class='bf_field_group elem-$slug'><div class='bf-input'><div class=\"dropzone featured-image-uploader dz-clickable\" id=\"$id\"  action='$action' data-entry='$entries_result' page='$page' max_file_size='$max_file_size'>
+						$box     = "<h2 class=\"hndle bf_woo\"><span class=\"woo_element_span\">$label_name</span></h2>
+                                    <div class='bf_field_group elem-$slug'><div class='bf-input'><div class=\"dropzone featured-image-uploader dz-clickable\" id=\"$id\"  action='$action' data-entry='$entries_result' page='$page' max_file_size='$max_file_size'>
                                          <div class=\"dz-default dz-message\" data-dz-message=\"\">
                                               <span>$message</span>
                                          </div>
                                         <input type='text' style='visibility: hidden' name='$id' value='$result_value' id='field_$id' data-rule-featured-image-error='true'   upload_error_validation_message='$upload_error_validation_message' $required  />
                                  </div></div></div>";
-						$form->addElement( new Element_HTML( "<label>$label_name</label>" ) );
+
 						$form->addElement( new Element_HTML( $box ) );
 						$form->addElement( new Element_HTML( "<span class='help-inline'>$description</span>" ) );
 


### PR DESCRIPTION
Form builder grid option not working for images