### PR TITLE
* Fixed the scroll after the form is submitted

### DIFF
--- a/assets/js/buddyforms.js
+++ b/assets/js/buddyforms.js
@@ -1058,13 +1058,14 @@ function BuddyForms() {
                     complete: function () {
                         BuddyFormsHooks.doAction('buddyforms:submit:enable');
                         // scroll to message after submit
-                        jQuery('html, body')
-                            .animate({
-                                scrollTop: (jQuery("#buddyforms_form_hero_" + id))
-                            }, 2000)
-                            .on('mousewheel', function () {
-                                jQuery('html, body').stop();
-                            });
+                        var scrollElement =  jQuery("#buddyforms_form_hero_" + id);
+                        if(scrollElement.length > 1) {
+                            jQuery('html, body').animate({scrollTop: scrollElement.offset().top - 100}, {
+                                duration: 500, complete: function () {
+                                    jQuery('html, body').on("click", function(){ jQuery('html, body').stop() });
+                                }
+                            }).one("click", function(){ jQuery('html, body').stop() });
+                        }
                         jQuery("#buddyforms_form_hero_" + id + " .form_wrapper form").LoadingOverlay("hide");
                         bf_form_errors();
                     }


### PR DESCRIPTION
**Describe the bug**
The form is not scrolling to the submission message after it is submitted. 

**How to replicate it**
- Create a form of any type.
- Publish it.
- Create a page.
- Insert content to the page, use the page `https://www.lipsum.com/` (generate 15 paragraphs)
- At the end insert the form shortcode.
- Submit the form and see the behavior

**Expected behavior**
When a form is submitted they scroll to top and it supposes to scroll to the form message.  

**Support Ticket**
https://secure.helpscout.net/conversation/914542030/25789?folderId=1428166