### PR TITLE
Fix: disable all the grid columns and rows on the permission tab when…

### DIFF
--- a/includes/admin/form-builder/meta-boxes/metabox-permissions.php
+++ b/includes/admin/form-builder/meta-boxes/metabox-permissions.php
@@ -154,11 +154,15 @@ function buddyforms_permissions_screen() {
 			unset( $form_user_role['draft'] );
 			unset( $form_user_role['admin-submission'] );
 		}
+        $disabled_class = '';
+        if ( ! buddyforms_core_fs()->is_paying_or_trial() ) {
+            $disabled_class = 'disabled';
+        }
 
 		$element = new Element_Checkbox( '<b>' . $role_name . '</b>', 'buddyforms_roles[' . $role_name . ']', $default_roles, array(
 			'value'  => $form_user_role,
 			'inline' => true,
-			'class'  => $role_name,
+			'class'  => $role_name.' '.$disabled_class,
 			'id'     => 'permission_for_' . $role_name,
 		) );
 


### PR DESCRIPTION
… the free version is installed