### PR TITLE
Fix/bf alert class

### DIFF
--- a/includes/resources/pfbc/Style/GlobalStyle.php
+++ b/includes/resources/pfbc/Style/GlobalStyle.php
@@ -9,6 +9,7 @@ $css_form_id = 'buddyforms_form_' . $form_slug;
 
     /* Alerts */
     .bf-alert {
+        display:block;
         padding: 15px;
         margin-bottom: 20px;
         border: 1px solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Avoid themes hiding messages like .success, .error, .warning with less specific CSS rules.