### PR TITLE
Invalid attributes in post excerpt

### DIFF
--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -649,7 +649,7 @@ function buddyforms_form_elements( &$form, $args, $recovering = false ) {
 							}
 							$wp_editor = preg_replace( '/<textarea/', "<textarea placeholder=\"" . $name . $required . "\"", $wp_editor );
 						} else {
-							$wp_editor_label = '<label for="buddyforms_form_"' . $name . '>' . $name . $required . '</label>';
+							$wp_editor_label = '<label for="'. $slug . '" >' . $name . $required . '</label>';
 						}
 
 						if ( isset( $customfield['hidden_field'] ) ) {

--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -653,7 +653,7 @@ function buddyforms_form_elements( &$form, $args, $recovering = false ) {
 						}
 
 						if ( isset( $customfield['hidden_field'] ) ) {
-							$form->addElement( new Element_Hidden( $name, $customfield_val, array() ) );
+							$form->addElement( new Element_Hidden( $slug, $customfield_val, array() ) );
 						} else {
 							if ( isset( $buddyforms[ $form_slug ]['layout']['desc_position'] ) && $buddyforms[ $form_slug ]['layout']['desc_position'] == 'above_field' ) {
 								$wp_editor = '<div class="bf_field_group bf_form_content">' . $wp_editor_label . '<span class="help-inline">' . $description . '</span><div class="bf_inputs bf-input">' . $wp_editor . '</div></div>';


### PR DESCRIPTION
- Invalid "name" attribute in post_excerpt when is a hidden field.
- Invalid "for" attribute (label) when the labels are shown.

![image](https://user-images.githubusercontent.com/36063539/94966695-b4048780-04cb-11eb-8a6f-009fc302dff0.png)
