### PR TITLE
Preventing Firefox from maintaining previously selected items.

### DIFF
--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -1114,7 +1114,14 @@ function buddyforms_form_elements( &$form, $args, $recovering = false ) {
 							$dropdown   = <<<MARKDOWN
 							<script>
 								jQuery(document).ready(function () {
-								    jQuery(".bf-select2-{$field_id}").select2({
+									const select2Elm = jQuery(".bf-select2-{$field_id}");
+									
+									// Prevent Firefox from maintaining previously selected items.
+									select2Elm.find('[selected="selected"]').each(function() {
+										jQuery(this).prop("selected", true);
+									});
+
+								    select2Elm.select2({
 								    	placeholder: function(){
 									        jQuery(this).data("placeholder");
 									    },


### PR DESCRIPTION
Preventing Firefox from maintaining previously selected items to ensure all selected items get showing.

More info:
https://www.loom.com/share/c281a860b523474b9894312cdcd9ff32