### PR TITLE
Issues in pages with multiples forms

### DIFF
--- a/assets/js/buddyforms.js
+++ b/assets/js/buddyforms.js
@@ -1493,6 +1493,9 @@ function BuddyForms() {
                                         jQuery("#buddyforms_form_" + id + " .form-actions .bf-draft").remove();
                                     }
                                     break;
+                                case 'form_slug': 
+                                    jQuery('#buddyforms_form_' + val + ' input[name="form_slug"]').val(val);
+                                    break;
                                 default:
                                     jQuery('input[name="' + i + '"]').val(val);
                             }

--- a/includes/form/form.php
+++ b/includes/form/form.php
@@ -205,11 +205,12 @@ function buddyforms_create_edit_form( $args, $echo = true ) {
 	if ( $post_id == 0 ) {
 		//check if auto-draft exist
 		global $wpdb;
-		$query   = $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE 1=1  AND post_title ='Auto Draft' AND post_content = '' AND post_author = %s AND post_type = %s ORDER BY ID DESC", $current_user->ID, $post_type );
+		$query   = $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} INNER JOIN wp_postmeta ON wp_posts.ID = wp_postmeta.post_id WHERE 1=1 AND post_title ='Auto Draft' AND post_content = '' AND post_author = %s AND post_type = %s AND wp_postmeta.meta_key = '_bf_form_slug' AND wp_postmeta.meta_value = %s ORDER BY ID DESC", $current_user->ID, $post_type, $form_slug );
 		$post_id = (int) $wpdb->get_var( $query );
 		if ( empty( $post_id ) ) {
 			$the_post = bf_get_default_post_to_edit( $post_type, true );
 			$post_id  = $the_post->ID;
+			update_post_meta( $post_id, '_bf_form_slug', $form_slug );
 		}
 	}
 


### PR DESCRIPTION
- Submitted form override the slug in other forms when submitted on a page with several forms.
- Previous entry is overridden by the next one when submitted entries from several forms by-one-by on the same page.

More info here:
https://www.loom.com/share/9fd91e233a804dbc8160b706c94c86b0?from_recorder=1