### PR TITLE
Improve the Disable CSS for description option

### DIFF
--- a/includes/resources/pfbc/FormView.php
+++ b/includes/resources/pfbc/FormView.php
@@ -64,8 +64,13 @@ abstract class FormView extends Base {
 	}
 
 	public function renderCSS() {
+		global $buddyforms, $form_slug;
+
+		if ( ! isset( $buddyforms[ $form_slug ]['layout']['desc_disable_css'] ) ) {
+			echo 'span.help-inline, span.help-block { color: #888; font-size: .9em; font-style: italic; }';
+		}
+		
 		echo 'label span.required { color: #B94A48; }';
-		echo 'span.help-inline, span.help-block { color: #888; font-size: .9em; font-style: italic; }';
 	}
 
 	public function renderJS() {

--- a/includes/resources/pfbc/Style/FormStyle.php
+++ b/includes/resources/pfbc/Style/FormStyle.php
@@ -346,6 +346,8 @@ $css_form_class = 'buddyforms-' . $form_slug;
 		display: block;
 	}
 
+	<?php if( empty($bfdesign['desc_disable_css']) ): ?>
+
 	/* Divi */ .et-db #et-boc .et-l .the_buddyforms_form .<?php echo esc_attr($css_form_class) ?> span.help-inline,
 	/* Divi */ .et-db #et-boc .et-l .the_buddyforms_form .<?php echo esc_attr($css_form_class) ?> span.help-block,
 	.the_buddyforms_form .<?php echo esc_attr($css_form_class) ?> span.help-inline,
@@ -354,6 +356,8 @@ $css_form_class = 'buddyforms-' . $form_slug;
 		font-style: italic;
 		font-weight: normal;
 	}
+
+	<?php endif; ?>
 
 	/* Divi */ .et-db #et-boc .et-l .the_buddyforms_form .<?php echo esc_attr($css_form_class) ?> .revision,
 	.the_buddyforms_form .<?php echo esc_attr($css_form_class) ?> .revision {


### PR DESCRIPTION
Improve the **Disable CSS for Description** option to disabled all the style-related with description if is enabled.