### PR TITLE
Fix conflict between user website and custom fields with a "website" slug.

### DIFF
--- a/includes/admin/user-meta.php
+++ b/includes/admin/user-meta.php
@@ -230,6 +230,15 @@ function buddyforms_get_value_from_user_meta( $user_id, $slug ) {
 }
 
 /**
+ * Get the array of avoid fields from the user. This fields are stored in the same wp user meta
+ * @deprecated since 2.5.30 - use instead buddyforms_avoid_user_fields_slugs_in_forms
+ * @return array
+ */
+function buddyforms_avoid_user_fields_in_forms() {
+	return buddyforms_avoid_user_fields_slugs_in_forms();
+}
+
+/**
  * Get the array of avoid fields slugs from the user. This fields are stored in the same wp user meta
  *
  * @return array

--- a/includes/admin/user-meta.php
+++ b/includes/admin/user-meta.php
@@ -215,7 +215,7 @@ function buddyforms_get_mapped_slug_from_user_meta( $slug ) {
  * @return string
  */
 function buddyforms_get_value_from_user_meta( $user_id, $slug ) {
-	if ( ! in_array( $slug, buddyforms_avoid_user_fields_in_forms() ) ) {
+	if ( ! in_array( $slug, buddyforms_avoid_user_fields_slugs_in_forms() ) ) {
 		return get_user_meta( $user_id, $slug, true );
 	} else {
 		$user  = get_userdata( $user_id );
@@ -230,11 +230,11 @@ function buddyforms_get_value_from_user_meta( $user_id, $slug ) {
 }
 
 /**
- * Get the array of avoid fields from the user. This fields are stored in the same wp user meta
+ * Get the array of avoid fields slugs from the user. This fields are stored in the same wp user meta
  *
  * @return array
  */
-function buddyforms_avoid_user_fields_in_forms() {
+function buddyforms_avoid_user_fields_slugs_in_forms() {
 	return apply_filters( 'buddyforms_avoid_user_fields', array(
 		'captcha',
 		'display_name',
@@ -244,6 +244,25 @@ function buddyforms_avoid_user_fields_in_forms() {
 		'user_last',
 		'user_pass',
 		'website',
+		'user_bio',
+	) );
+}
+
+/**
+ * Get the array of avoid fields types from the user. This fields are stored in the same wp user meta
+ *
+ * @return array
+ */
+function buddyforms_avoid_user_fields_types_in_forms() {
+	return apply_filters( 'buddyforms_avoid_user_fields', array(
+		'captcha',
+		'display_name',
+		'user_login',
+		'user_email',
+		'user_first',
+		'user_last',
+		'user_pass',
+		'user_website',
 		'user_bio',
 	) );
 }

--- a/includes/form/form-elements.php
+++ b/includes/form/form-elements.php
@@ -86,21 +86,29 @@ function buddyforms_form_elements( &$form, $args, $recovering = false ) {
 
 		if ( $slug != '' ) {
 
+			$field_type      = '';
 			$customfield_val = '';
+
+			if ( isset( $customfield['type'] ) ) {
+				$field_type = $customfield['type'];
+			}
+
 			//Get form field value when the form is editing
 			if ( $action === 'edit' ) {
 				$customfield_val = get_post_meta( $post_id, $slug, true );
 			}
-			if ( in_array( $slug, buddyforms_avoid_user_fields_in_forms() ) && is_user_logged_in() ) {
-				$customfield_val = buddyforms_get_value_from_user_meta( $current_user_id, $slug );
+
+			// Get custom field value from user meta if the field it's an user's type.
+			if ( in_array( $field_type, buddyforms_avoid_user_fields_types_in_forms() ) && is_user_logged_in() ) {
+				$usermeta = buddyforms_get_value_from_user_meta( $current_user_id, $slug );
+				$customfield_val = empty( $usermeta ) ? $customfield_val : $usermeta;
 			}
 
 			if ( isset( $_POST[ $slug ] ) && empty( $customfield_val ) ) {
 				$customfield_val = $_POST[ $slug ];
 			}
 
-			if ( isset( $customfield['type'] ) ) {
-				$field_type = sanitize_title( $customfield['type'] );
+			if ( ! empty ( $field_type ) ) {
 				if ( empty( $customfield_val ) ) {
 					$default_value = isset( $customfield['default'] ) ? $customfield['default'] : '';
 					if ( ! empty( $_GET[ $slug ] ) && ! in_array( $field_type, array( 'user_login', 'user_pass' ) ) ) {
@@ -1115,7 +1123,7 @@ function buddyforms_form_elements( &$form, $args, $recovering = false ) {
 							<script>
 								jQuery(document).ready(function () {
 									const select2Elm = jQuery(".bf-select2-{$field_id}");
-									
+
 									// Prevent Firefox from maintaining previously selected items.
 									select2Elm.find('[selected="selected"]').each(function() {
 										jQuery(this).prop("selected", true);


### PR DESCRIPTION
Users can add custom fields (like Text, URL, so on) in Post Type forms. If the custom field has the slug setting up to "website" then it will retrieve the value of the user website field for the current user, stored on the usermeta instead of pick up the value from the postmeta.

@TODO: Fix validation of URL when user_website and custom field with "website" are on the same form.
@TODO: Avoid using "website" as a slug for custom fields.